### PR TITLE
Add SBOM/provenance attestations and PR security comments

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -198,20 +198,37 @@ jobs:
             "builder": {
               "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             },
-            "buildType": "https://github.com/Attestations/GitHubActions@v1",
+            "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
             "invocation": {
-              "parameters": {
-                "ref": "${{ github.ref_name }}",
-                "sha": "${{ github.sha }}"
+              "configSource": {
+                "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
+                "digest": {
+                  "sha1": "${{ github.sha }}"
+                },
+                "entryPoint": ".github/workflows/build-images.yml"
               },
+              "parameters": {},
               "environment": {
-                "repository": "${{ github.repository }}",
-                "trigger": "${{ github.event_name }}"
+                "github_event_name": "${{ github.event_name }}",
+                "github_ref": "${{ github.ref }}",
+                "github_run_id": "${{ github.run_id }}"
               }
+            },
+            "metadata": {
+              "buildInvocationID": "${{ github.run_id }}/${{ github.run_attempt }}",
+              "completeness": {
+                "parameters": false,
+                "environment": false,
+                "materials": false
+              },
+              "reproducible": false
             },
             "materials": [
               {
-                "uri": "git+https://github.com/${{ github.repository }}@${{ github.sha }}"
+                "uri": "git+https://github.com/${{ github.repository }}",
+                "digest": {
+                  "sha1": "${{ github.sha }}"
+                }
               }
             ]
           }

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -246,6 +246,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          set -euo pipefail
           python3 .github/scripts/analyse-scan-results.py scan-results/ \
             | tee -a "$GITHUB_STEP_SUMMARY" > /tmp/claude-summary.md
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -181,6 +181,46 @@ jobs:
           cosign sign --yes \
             "${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image.repo }}@${{ steps.push.outputs.digest }}"
 
+      # ── Attest SBOM and build provenance (Sigstore / Rekor) ───────────────
+      - name: Attest SBOM with Cosign
+        if: github.event_name != 'pull_request'
+        run: |
+          cosign attest --yes \
+            --predicate "sbom-${{ matrix.image.name }}.spdx.json" \
+            --type spdxjson \
+            "${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image.repo }}@${{ steps.push.outputs.digest }}"
+
+      - name: Generate and attest build provenance
+        if: github.event_name != 'pull_request'
+        run: |
+          cat > provenance.json <<EOF
+          {
+            "builder": {
+              "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            },
+            "buildType": "https://github.com/Attestations/GitHubActions@v1",
+            "invocation": {
+              "parameters": {
+                "ref": "${{ github.ref_name }}",
+                "sha": "${{ github.sha }}"
+              },
+              "environment": {
+                "repository": "${{ github.repository }}",
+                "trigger": "${{ github.event_name }}"
+              }
+            },
+            "materials": [
+              {
+                "uri": "git+https://github.com/${{ github.repository }}@${{ github.sha }}"
+              }
+            ]
+          }
+          EOF
+          cosign attest --yes \
+            --predicate provenance.json \
+            --type slsaprovenance \
+            "${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image.repo }}@${{ steps.push.outputs.digest }}"
+
   # ─────────────────────────────────────────────────────────────────────────────
   # Review all scan results with Claude after every build run
   # ─────────────────────────────────────────────────────────────────────────────
@@ -207,4 +247,20 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python3 .github/scripts/analyse-scan-results.py scan-results/ \
-            >> "$GITHUB_STEP_SUMMARY"
+            | tee -a "$GITHUB_STEP_SUMMARY" > /tmp/claude-summary.md
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Post security summary as PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body-file /tmp/claude-summary.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Does
+
+Base Image Bakery is a CI/CD pipeline (GitHub Actions) that builds, vulnerability-scans, signs, and publishes hardened Docker base images to Docker Hub. There is no application code to run locally — the primary artefacts are Dockerfiles and the workflow that processes them.
+
+## Building Images Locally
+
+```bash
+# Build a single image (from repo root — context must include certs/)
+docker build -f Dockerfiles/alpine/Dockerfile \
+  --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+  --build-arg VCS_REF=$(git rev-parse --short HEAD) \
+  --build-arg VERSION=3.21 \
+  --build-arg IMAGE_SOURCE=https://github.com/andrewblooman/Base-Image-Bakery \
+  -t base-alpine:local .
+
+# Scan locally with Grype
+grype base-alpine:local --output json --file grype-results-alpine.json
+
+# Run the Claude analysis script against local scan results
+ANTHROPIC_API_KEY=<key> python3.14 .github/scripts/analyse-scan-results.py ./
+```
+
+## Architecture
+
+### Pipeline flow (`build-images.yml`)
+
+Each image runs as a **parallel matrix job**:
+1. Build image locally (not pushed) tagged `bakery/<name>:scan-target`
+2. Grype scan → JSON artefact (90-day retention)
+3. Syft SBOM → SPDX JSON artefact (90-day retention)
+4. Push to Docker Hub (skipped on PRs)
+5. Cosign keyless sign via GitHub OIDC (skipped on PRs)
+6. `cosign attest --type spdxjson` — attaches SBOM to image in Rekor (skipped on PRs)
+7. `cosign attest --type slsaprovenance` — attaches build provenance to image in Rekor (skipped on PRs)
+
+After all matrix jobs, a single `review-scan-results` job downloads all Grype artefacts and calls `analyse-scan-results.py`, which POSTs to the Anthropic API and writes a Markdown security report to `$GITHUB_STEP_SUMMARY`. On pull requests the report is also posted as a PR comment via `gh pr comment`, authenticated with a GitHub App token generated from `APP_ID` + `APP_PRIVATE_KEY` (security-engineer-agent).
+
+### Dockerfile conventions
+
+Every Dockerfile must:
+- Accept `BUILD_DATE`, `VCS_REF`, `VERSION`, and `IMAGE_SOURCE` build args
+- `COPY certs/ /usr/local/share/ca-certificates/custom/` then run the OS cert-update command
+- Apply security patches (`apk upgrade --no-cache` or `apt-get upgrade -y`)
+- Set OCI-standard `LABEL` instructions
+- Create and switch to a non-root user (exception: docker-in-docker requires root)
+
+### Adding a new image
+
+1. Create `Dockerfiles/<name>/Dockerfile` following the conventions above
+2. Add a matrix entry to `.github/workflows/build-images.yml` under `jobs.build-and-push.strategy.matrix.image`
+3. Update the Image Inventory table in `README.md`
+
+### CA certificates
+
+Drop PEM-format `.crt` files into `certs/`. They are baked into every image at build time. Non-`.crt` files are excluded via `.dockerignore`.
+
+### Updating a base image version
+
+1. Change the `ARG <X>_VERSION=` default in the Dockerfile
+2. Update the `version` field in the workflow matrix entry
+3. Update the Image Inventory table in `README.md`
+
+## Required Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `DOCKERHUB_USERNAME` | Docker Hub username |
+| `DOCKERHUB_TOKEN` | Docker Hub access token (Read & Write) |
+| `ANTHROPIC_API_KEY` | Used by `analyse-scan-results.py` to call Claude |
+| `APP_ID` | GitHub App ID for security-engineer-agent (posts PR comments) |
+| `APP_PRIVATE_KEY` | GitHub App private key (PEM) for security-engineer-agent |
+
+## Python Script (`analyse-scan-results.py`)
+
+Uses only the Python standard library plus the Anthropic REST API (raw `urllib.request` — no SDK). Reads `grype-results-*.json` files from a directory, builds a summarised prompt (capping Critical/High findings at 20 per image), and calls `claude-opus-4-5` with `max_tokens=4096`. Output goes to stdout; the workflow captures it with `tee` to both `$GITHUB_STEP_SUMMARY` and `/tmp/claude-summary.md` (used for the PR comment).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ docker build -f Dockerfiles/alpine/Dockerfile \
 grype base-alpine:local --output json --file grype-results-alpine.json
 
 # Run the Claude analysis script against local scan results
-ANTHROPIC_API_KEY=<key> python3.14 .github/scripts/analyse-scan-results.py ./
+ANTHROPIC_API_KEY=<key> python3 .github/scripts/analyse-scan-results.py ./
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ All images include:
 - ✅ OCI-standard image labels (`org.opencontainers.image.*`)
 - ✅ Non-root application user (except Docker-in-Docker, which requires root)
 - ✅ Vulnerability scan report (Grype) stored as a workflow artefact
-- ✅ SBOM in SPDX JSON format stored as a workflow artefact
+- ✅ SBOM in SPDX JSON format stored as a workflow artefact and attested in Rekor
 - ✅ Cosign keyless signature verifiable via Sigstore / Rekor
+- ✅ SLSA build provenance attestation in Rekor
 
 ---
 
@@ -70,9 +71,35 @@ Replace `base-alpine` with the image you are verifying. A successful verificatio
 Rekor transparency-log entry and confirms the image was produced by this repository's
 GitHub Actions workflow.
 
+### Verifying the SBOM attestation
+
+The SBOM is attached to each image as a Cosign attestation in Rekor, in addition to being
+available as a workflow artefact:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp="https://github.com/andrewblooman/Base-Image-Bakery/.github/workflows/build-images.yml" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  andrewblooman/base-alpine:latest
+```
+
+### Verifying build provenance
+
+Each image includes a SLSA provenance attestation recording the repository, commit SHA, and
+GitHub Actions run that produced it:
+
+```bash
+cosign verify-attestation \
+  --type slsaprovenance \
+  --certificate-identity-regexp="https://github.com/andrewblooman/Base-Image-Bakery/.github/workflows/build-images.yml" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  andrewblooman/base-alpine:latest
+```
+
 ### Checking the SBOM
 
-SPDX JSON SBOMs are attached to every workflow run as artefacts.  
+SPDX JSON SBOMs are attached to every workflow run as artefacts and as a Cosign attestation.  
 You can also generate a fresh SBOM locally:
 
 ```bash
@@ -128,6 +155,8 @@ Set the following secrets under **Settings → Secrets and variables → Actions
 | `DOCKERHUB_USERNAME` | Docker Hub account username (e.g. `andrewblooman`) |
 | `DOCKERHUB_TOKEN` | Docker Hub [access token](https://docs.docker.com/docker-hub/access-tokens/) with **Read & Write** permissions |
 | `ANTHROPIC_API_KEY` | Anthropic API key used by the Claude vulnerability-review step |
+| `APP_ID` | GitHub App ID for the security-engineer-agent (posts PR comments) |
+| `APP_PRIVATE_KEY` | GitHub App private key (PEM) for the security-engineer-agent |
 
 ### Reviewing vulnerability scan results
 
@@ -138,6 +167,8 @@ After each pipeline run:
 3. Expand the **Analyse scan results with Claude** step to read Claude's Markdown security report.
 4. Download the `grype-results-<image>` artefacts for raw Grype JSON output.
 5. Download the `sbom-<image>` artefacts for SPDX SBOMs.
+
+On pull requests, Claude's security summary is also posted automatically as a PR comment.
 
 Artefacts are retained for **90 days**.
 
@@ -170,13 +201,16 @@ Artefacts are retained for **90 days**.
 │  │  4. Syft SBOM generation      →  artefact (90-day retention) │   │
 │  │  5. Push to Docker Hub        (skipped on PRs)               │   │
 │  │  6. Cosign keyless sign       (skipped on PRs)               │   │
+│  │  7. Cosign attest SBOM        (skipped on PRs)               │   │
+│  │  8. Cosign attest provenance  (skipped on PRs)               │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 │                                                                     │
 │  After all images:                                                  │
 │  ┌──────────────────────────────────────────────────────────────┐   │
-│  │  7. Download all scan results                                │   │
-│  │  8. Claude (Anthropic API) analyses findings                 │   │
-│  │  9. Markdown report → GitHub Step Summary                    │   │
+│  │  9.  Download all scan results                               │   │
+│  │  10. Claude (Anthropic API) analyses findings                │   │
+│  │  11. Markdown report → GitHub Step Summary                   │   │
+│  │  12. Post report as PR comment  (PRs only)                   │   │
 │  └──────────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary

- **SBOM attestation**: Each image now has its SPDX JSON SBOM attached as a `cosign attest --type spdxjson` attestation in the Rekor transparency log, verifiable with `cosign verify-attestation --type spdxjson`
- **SLSA provenance**: Each image now has a build provenance record (repo, SHA, run ID, trigger) attached via `cosign attest --type slsaprovenance`
- **PR security comments**: Claude's vulnerability summary is posted automatically as a PR comment on pull requests, authenticated via the security-engineer-agent GitHub App (`APP_ID` + `APP_PRIVATE_KEY`)
- **CLAUDE.md**: Added guidance file for Claude Code sessions covering build commands, pipeline architecture, and Dockerfile conventions
- **README**: Updated with `cosign verify-attestation` commands, revised pipeline diagram, and new required secrets

## New secrets required

| Secret | Purpose |
|--------|---------|
| `APP_ID` | GitHub App ID for security-engineer-agent |
| `APP_PRIVATE_KEY` | GitHub App private key (PEM) for security-engineer-agent |

## Test plan

- [ ] Open a PR touching a Dockerfile — confirm Claude posts a security summary comment signed by the security-engineer-agent app
- [ ] Merge to `main` — confirm `cosign attest` steps succeed for all 5 images
- [ ] Run `cosign verify-attestation --type spdxjson andrewblooman/base-alpine:latest` to confirm SBOM attestation is in Rekor
- [ ] Run `cosign verify-attestation --type slsaprovenance andrewblooman/base-alpine:latest` to confirm provenance attestation

🤖 Generated with [Claude Code](https://claude.ai/code)