### PR TITLE
fix: pin sigstore/cosign-installer to v4.1.1

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -325,7 +325,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Download digest artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

- `sigstore/cosign-installer` does not publish major-version alias tags (unlike `actions/checkout`); only full semver releases exist
- The previous commit (5f9e9dc) bumped the action to `@v4`, which does not exist, causing all cosign jobs to fail immediately with _"Unable to resolve action `sigstore/cosign-installer@v4`, unable to find version `v4`"_
- Pins to `v4.1.1` (latest release, 2026-03-26), which ships cosign v3.0.5

## Test plan

- [ ] Verify the `sign-and-attest` job resolves and installs cosign successfully on the next workflow run
- [ ] Confirm signed images appear on Docker Hub after a merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)