### PR TITLE
fix: add Docker Hub login to cosign job

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -327,6 +327,12 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.1
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Download digest artifact
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- The `cosign` job runs as a separate job after `push` and does not inherit the Docker Hub session from the `push` job
- `cosign sign` and `cosign attest` push OCI signature/attestation artifacts back to Docker Hub, requiring write credentials
- Without login, the Docker Hub token scope check returns `401 Unauthorized: access token has insufficient scopes`
- Adds `docker/login-action@v4` to the `cosign` job before any signing steps, mirroring the pattern already used in the `push` job

## Test plan

- [ ] Re-run the `sign-and-attest` job and confirm cosign successfully pushes signatures to Docker Hub
- [ ] Verify signed image signatures are visible via `cosign verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)